### PR TITLE
Fix issue with eval function in query of Dataframe

### DIFF
--- a/danfojs/src/core/frame.js
+++ b/danfojs/src/core/frame.js
@@ -1023,7 +1023,7 @@ export class DataFrame extends Ndframe {
             let elem = data_value[column_index]
             //use eval function for easy operation
             //eval() takes in a string expression e.g eval('2>5')
-            if (eval(`${elem}${operator}${value}`)) {
+            if (eval(`elem${operator}value`)) {
                 new_data.push(data_value);
                 new_index.push(index[i])
 

--- a/danfojs/tests/core/frame.js
+++ b/danfojs/tests/core/frame.js
@@ -905,6 +905,14 @@ describe("DataFrame", function () {
             let query_data = [[4, 5, 6], [20, 30, 40], [39, 89, 78]]
             assert.deepEqual(query_df.values, query_data)
         });
+        it("Get the Dataframe containing rows with the filtered column in String values", function () {
+            let data = { "Abs": [20, 30, 47] , "Count": [34, 4, 5] , "country code" :["NG", "FR", "GH"] };
+            let cols = [ "Abs" , "Count", "country code"];
+            let df = new DataFrame(data, { columns: cols });
+            let query_df = df.query({column: "country code", is: "==", to: "NG"});
+            let query_data = [[20, 34, "NG"]];
+            assert.deepEqual(query_df.values, query_data);
+        });
         it("Print Error for value key not specified", function () {
 
             let data = [[1, 2, 3], [4, 5, 6], [20, 30, 40], [39, 89, 78]]


### PR DESCRIPTION
## Description
Query issue when take a dataframe with mix types in the values mainly when we have strings in the value of the a column. When I provide this data:

```js
let data = { "Abs": [20, 30, 47] ,
            "Count": [34, 4, 5] ,
            "country code": ["NG", "FR", "GH"] };
let cols = [ "Abs" , "Count", "country code"];
let df = new DataFrame(data, { columns: cols });
let query = df.query({column: "country code", is: "==", to: "NG"});
query.print();
```

I got `ReferenceError: NG is not defined`, I figured out that the problem is in eval function that is used in frame.js

```js
if (eval(`${elem}${operator}${value}`)) {
  new_data.push(data_value);
  new_index.push(index[i]);
}
```

becase eval function resolve the string to NG==NG and the engine try to get the variable NG that doesn't exits, I fix this by changing to

```js
if (eval(`elem${operator}value`)) {
  new_data.push(data_value);
  new_index.push(index[i]);
}
```

and get the desired output

![image](https://user-images.githubusercontent.com/32320832/92673709-65573980-f2e1-11ea-959b-9f63e1f3e49c.png)

## Related Issue
Samira in issue #22 report a problem in query function when she try to query mix values in the DataFrame (string, int).





