### PR TITLE
fixed table issue where header and cell styles overwrite each other

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ coverage
 .nyc_output
 dist
 danfojs/data
+.DS_Store
+.idea/
+danfojs/.DS_Store
+danfojs/tests/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ dist
 danfojs/data
 .DS_Store
 .idea/
-danfojs/.DS_Store
-danfojs/tests/.DS_Store

--- a/danfojs/src/plotting/plot.js
+++ b/danfojs/src/plotting/plot.js
@@ -574,7 +574,6 @@ export class Plot {
 
             trace["y"] = y
             trace['type'] = "box"
-            
 
             newPlot(this.div, [trace], this_config['layout']);
 
@@ -815,7 +814,7 @@ export class Plot {
 
         if (this_config['cell_style']) {
             Object.keys(this_config['cell_style']).forEach(param => {
-                header[param] = this_config['cell_style'][param]
+                cells[param] = this_config['cell_style'][param]
             })
         }
         var data = [{


### PR DESCRIPTION
# Problem

In Tables, the header and cell styles overwrite each other. See https://github.com/opensource9ja/danfojs/issues/34 for more details.

# Solution

See the one line change in `danfojs/src/plotting/plot.js`: 

`header[param] = this_config['cell_style'][param]` should be `cells[param] = this_config['cell_style'][param]`

# Screenshot of front-end with the fix applied

<img width="893" alt="Screen Shot 2020-10-13 at 8 49 59 AM" src="https://user-images.githubusercontent.com/88433/95870831-91c40280-0d32-11eb-9cc7-af087128289c.png">

# HTML of the screenshot above, if you'd like to recreate

```
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Table Test</title>
  <script src="index.js"></script>
  <script>
    const testData = [
      {
        firstName: "Christopher",
        lastName: "Wallace"
      }, {
        firstName: "Percy",
        lastName: "Miller"
      },
      {
        firstName: "Daniel",
        lastName: "Dumile"
      }
    ]
    document.addEventListener("DOMContentLoaded", function () {
      const header_style = {
        align: ["center"],
        fill: {color: ['#0984e3']},
        font: {family: "Georgia", size: 15, color: "white"}
      }
      const cell_style = {
        align: ["center"],
        line: {color: "black", width: 1},
        font: {family: "Arial", size: 15, color: "#333"},
        height: 30
      }
      const df = new dfd.DataFrame(testData)
      df.plot('table-example').table({header_style: header_style, cell_style: cell_style})
    });
  </script>
</head>
<body>
  <h1>Table Example</h1>
  <div id="table-example">
  </div>
</body>
</html>

```

