### PR TITLE
Add library target "window"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
         path: path.resolve(__dirname, "dist"),
         filename: 'index.js',
         library: 'dfd',
+        libraryTarget: 'window'
     },
     module: {
         rules: [


### PR DESCRIPTION
In order to expose the dfd variable reliably (also in case of esm loads) we ask webpack to assign dfd to the window object.