### PR TITLE
to_csv functioning correctly and tested

### DIFF
--- a/danfojs/src/core/frame.js
+++ b/danfojs/src/core/frame.js
@@ -58,6 +58,26 @@ export class DataFrame extends Ndframe {
             })
         });
     }
+    /**
+     * Write a CSV file of the DataFrame contents
+     * @param {string} csvFilePath Path to save CSV when in Node.js form
+     * @returns {Promise<String>} CSV representation of Object data
+     *     
+     */
+    async to_csv(csvFilePath = "") {
+        const csvContent = await super.to_csv();
+        // behave differently for Node vs Web
+        if (typeof window === "undefined") {
+            // Write CSV on Node.js
+            const fs = require("fs");
+            fs.writeFileSync(csvFilePath, csvContent, (err) => err && console.error(err));
+        } else {
+            // Download CSV on Web
+            const webCSV = "data:text/csv;charset=utf-8," + csvContent;
+            window.open(encodeURI(webCSV));
+        }
+        return csvContent;
+    }    
 
     /**
      * Drop a list of rows or columns base on the specified axis 

--- a/danfojs/tests/core/frame.js
+++ b/danfojs/tests/core/frame.js
@@ -1,8 +1,35 @@
 import { assert } from "chai"
 import { DataFrame } from '../../src/core/frame'
 import { Series } from "../../src/core/series";
+import fs from "fs";
+
+const testCSVPath = "./tester.csv"
 
 describe("DataFrame", function () {
+
+    describe("to_csv", function () {
+        afterEach(function(){
+            // Clean up generated file
+            fs.unlinkSync(testCSVPath)
+        })
+        
+        it("save dataframe to CSV file", async function () {
+            let data = [[1, 2, 3], [4, 5, 6]]
+            let cols = ["A", "B", "C"]
+            let df = new DataFrame(data, { columns: cols })  
+            await df.to_csv(testCSVPath)  
+            assert.isTrue(fs.existsSync(testCSVPath))               
+        })
+
+        it("return dataframe csv string", async function () {
+            let data = [[1, 2, 3], [4, 5, 6]]
+            let cols = ["A", "B", "C"]
+            let df = new DataFrame(data, { columns: cols })  
+            const csvContent = await df.to_csv(testCSVPath)  
+            assert.deepEqual(csvContent, "A,B,C\n1,2,3\n4,5,6\n")               
+        })        
+
+    })
 
     describe("drop", function () {
         it("throw error for wrong row index", function () {


### PR DESCRIPTION
This code adds two tests for DataFrames and provides the documented `to_csv` functionality when in Node form and provides a download version in web.

Should close #67 