### PR TITLE
Replace map with forEach

### DIFF
--- a/dist/core/get_dummies.js
+++ b/dist/core/get_dummies.js
@@ -65,7 +65,7 @@ function get_dummy(kwargs = {}) {
 
     if (!columns) {
       columns = [];
-      in_data.col_types.map((x, i) => {
+      in_data.col_types.forEach((x, i) => {
         if (x == "string") {
           let name_column = in_data.columns[i];
           columns.push(name_column);


### PR DESCRIPTION
The callback provided to the map call on this array should return a value, otherwise map will always return an array of undefined values. If the desired behaviour is to just iterate through all elements, then consider using forEach or a for-of loop instead.