### PR TITLE
Add yarn as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "source-map-loader": "^1.0.0",
     "transform-loader": "^0.2.4",
     "webpack": "5.21.2",
-    "webpack-cli": "4.5.0"
+    "webpack-cli": "4.5.0",
+    "yarn": "^1.22.10"
   },
   "nyc": {
     "reporter": [


### PR DESCRIPTION
The test script uses yarn which isn't listed as dev dependency. Should it be?