### PR TITLE
Do not return all data in sample for n < 1

### DIFF
--- a/danfojs/src/core/frame.js
+++ b/danfojs/src/core/frame.js
@@ -270,11 +270,8 @@ export class DataFrame extends Ndframe {
    * @returns DataFrame
    */
   sample(num = 5) {
+    utils._validate_nonnegative_int(num);
     //TODO: Use different sampling strategy
-    if (num < 0) {
-      throw new Error("num cannot be negative");
-    }
-
     if (num > this.values.length) {
       //return all values
       let config = { columns: this.column_names };

--- a/danfojs/src/core/frame.js
+++ b/danfojs/src/core/frame.js
@@ -271,7 +271,7 @@ export class DataFrame extends Ndframe {
    */
   sample(num = 5) {
     //TODO: Use different sampling strategy
-    if (num > this.values.length || num < 1) {
+    if (num > this.values.length) {
       //return all values
       let config = { columns: this.column_names };
       return new DataFrame(this.values, config);

--- a/danfojs/src/core/frame.js
+++ b/danfojs/src/core/frame.js
@@ -273,7 +273,9 @@ export class DataFrame extends Ndframe {
     //TODO: Use different sampling strategy
     if (num < 0) {
       throw new Error("num cannot be negative");
-    } else if (num > this.values.length) {
+    }
+
+    if (num > this.values.length) {
       //return all values
       let config = { columns: this.column_names };
       return new DataFrame(this.values, config);

--- a/danfojs/src/core/frame.js
+++ b/danfojs/src/core/frame.js
@@ -271,7 +271,9 @@ export class DataFrame extends Ndframe {
    */
   sample(num = 5) {
     //TODO: Use different sampling strategy
-    if (num > this.values.length) {
+    if (num < 0) {
+      throw new Error("num cannot be negative");
+    } else if (num > this.values.length) {
       //return all values
       let config = { columns: this.column_names };
       return new DataFrame(this.values, config);

--- a/danfojs/src/core/series.js
+++ b/danfojs/src/core/series.js
@@ -100,7 +100,7 @@ export class Series extends NDframe {
     * @returns {Series}
     */
   sample(num = 5) {
-    if (num > this.values.length || num < 1) {
+    if (num > this.values.length) {
       let config = { columns: this.column_names };
       return new Series(this.values, config);
     } else {
@@ -1311,4 +1311,3 @@ export class Series extends NDframe {
   }
 
 }
-

--- a/danfojs/src/core/series.js
+++ b/danfojs/src/core/series.js
@@ -100,10 +100,7 @@ export class Series extends NDframe {
     * @returns {Series}
     */
   sample(num = 5) {
-    if (num < 0) {
-      throw new Error("num cannot be negative");
-    }
-
+    utils._validate_nonnegative_int(num);
     if (num > this.values.length) {
       let config = { columns: this.column_names };
       return new Series(this.values, config);

--- a/danfojs/src/core/series.js
+++ b/danfojs/src/core/series.js
@@ -102,7 +102,9 @@ export class Series extends NDframe {
   sample(num = 5) {
     if (num < 0) {
       throw new Error("num cannot be negative");
-    } else if (num > this.values.length) {
+    }
+
+    if (num > this.values.length) {
       let config = { columns: this.column_names };
       return new Series(this.values, config);
     } else {

--- a/danfojs/src/core/series.js
+++ b/danfojs/src/core/series.js
@@ -100,7 +100,9 @@ export class Series extends NDframe {
     * @returns {Series}
     */
   sample(num = 5) {
-    if (num > this.values.length) {
+    if (num < 0) {
+      throw new Error("num cannot be negative");
+    } else if (num > this.values.length) {
       let config = { columns: this.column_names };
       return new Series(this.values, config);
     } else {

--- a/danfojs/src/core/utils.js
+++ b/danfojs/src/core/utils.js
@@ -729,4 +729,10 @@ export class Utils {
 
     return sorted_idx.map(([ , item ]) => item);
   }
+
+  _validate_nonnegative_int(n) {
+    if (n < 0 || Math.floor(n) !== n) {
+      throw new Error(`${n} is not a nonnegative integer`);
+    }
+  }
 }

--- a/danfojs/tests/core/frame.js
+++ b/danfojs/tests/core/frame.js
@@ -182,11 +182,17 @@ describe("DataFrame", function () {
       let df = new dfd.DataFrame(data, { columns: cols });
       assert.deepEqual(df.sample(6).shape, [ 5, 3 ]);
     });
-    it("Return no data if n of sample is less than 1", function () {
+    it("Return no data if n of sample is 0", () => {
       let data = [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 20, 30, 40 ], [ 39, 89, 78 ], [ 100, 200, 300 ] ];
       let cols = [ "A", "B", "C" ];
       let df = new dfd.DataFrame(data, { columns: cols });
-      assert.deepEqual(df.sample(-1).shape, [ 0, 3 ]);
+      assert.deepEqual(df.sample(0).shape, [ 0, 3 ]);
+    });
+    it("Throw error for negative num", () => {
+      let data = [ [ 1, 2, 3 ], [ 4, 5, 6 ] ];
+      let cols = [ "A", "B" ];
+      let df = new dfd.DataFrame(data, { columns: cols });
+      assert.throws(() => { df.sample(-1); }, Error, "num cannot be negative");
     });
   });
 

--- a/danfojs/tests/core/frame.js
+++ b/danfojs/tests/core/frame.js
@@ -190,7 +190,7 @@ describe("DataFrame", function () {
     });
     it("Throw error for negative num", () => {
       let data = [ [ 1, 2, 3 ], [ 4, 5, 6 ] ];
-      let cols = [ "A", "B" ];
+      let cols = [ "A", "B", "C" ];
       let df = new dfd.DataFrame(data, { columns: cols });
       assert.throws(() => { df.sample(-1); }, Error, "num cannot be negative");
     });

--- a/danfojs/tests/core/frame.js
+++ b/danfojs/tests/core/frame.js
@@ -182,11 +182,11 @@ describe("DataFrame", function () {
       let df = new dfd.DataFrame(data, { columns: cols });
       assert.deepEqual(df.sample(6).shape, [ 5, 3 ]);
     });
-    it("Return all values if n of sample is less than 1", function () {
+    it("Return no data if n of sample is less than 1", function () {
       let data = [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 20, 30, 40 ], [ 39, 89, 78 ], [ 100, 200, 300 ] ];
       let cols = [ "A", "B", "C" ];
       let df = new dfd.DataFrame(data, { columns: cols });
-      assert.deepEqual(df.sample(-1).shape, [ 5, 3 ]);
+      assert.deepEqual(df.sample(-1).shape, [ 0, 3 ]);
     });
   });
 

--- a/danfojs/tests/core/frame.js
+++ b/danfojs/tests/core/frame.js
@@ -192,7 +192,7 @@ describe("DataFrame", function () {
       let data = [ [ 1, 2, 3 ], [ 4, 5, 6 ] ];
       let cols = [ "A", "B", "C" ];
       let df = new dfd.DataFrame(data, { columns: cols });
-      assert.throws(() => { df.sample(-1); }, Error, "num cannot be negative");
+      assert.throws(() => { df.sample(-1); }, Error, /is not a nonnegative integer/);
     });
   });
 

--- a/danfojs/tests/core/series.js
+++ b/danfojs/tests/core/series.js
@@ -88,10 +88,14 @@ describe("Series", function () {
       let sf = new dfd.Series(data);
       assert.deepEqual(sf.sample(21).values.length, data.length);
     });
-    it("Return no data if n of sample is less than 1", function () {
+    it("Return no data if n of sample is 0", () => {
       let data = [ 1, 2, 3, 4, 5, 620, 30, 40, 39, 89, 78 ];
       let sf = new dfd.Series(data);
-      assert.deepEqual(sf.sample(-2).values.length, 0);
+      assert.deepEqual(sf.sample(0).values.length, 0);
+    });
+    it("Throw error if num is negative", () => {
+      let sf = new dfd.Series([ 1, 2, 3 ]);
+      assert.throws(() => { sf.sample(-1); }, Error, "num cannot be negative");
     });
   });
 

--- a/danfojs/tests/core/series.js
+++ b/danfojs/tests/core/series.js
@@ -88,10 +88,10 @@ describe("Series", function () {
       let sf = new dfd.Series(data);
       assert.deepEqual(sf.sample(21).values.length, data.length);
     });
-    it("Return all values if n of sample is less than 1", function () {
+    it("Return no data if n of sample is less than 1", function () {
       let data = [ 1, 2, 3, 4, 5, 620, 30, 40, 39, 89, 78 ];
       let sf = new dfd.Series(data);
-      assert.deepEqual(sf.sample(-2).values.length, data.length);
+      assert.deepEqual(sf.sample(-2).values.length, 0);
     });
   });
 

--- a/danfojs/tests/core/series.js
+++ b/danfojs/tests/core/series.js
@@ -95,7 +95,7 @@ describe("Series", function () {
     });
     it("Throw error if num is negative", () => {
       let sf = new dfd.Series([ 1, 2, 3 ]);
-      assert.throws(() => { sf.sample(-1); }, Error, "num cannot be negative");
+      assert.throws(() => { sf.sample(-1); }, Error, /is not a nonnegative integer/);
     });
   });
 


### PR DESCRIPTION
I think this behavior would be more intuitive to users (e.g., if someone explicitly requests a sample of size 0 it would be surprising to get back all the data. Also a negative sample size is likely to be a mistake so raising an error would be helpful.)