### PR TITLE
Refactor __shuffle in utils.js

### DIFF
--- a/danfojs/src/core/utils.js
+++ b/danfojs/src/core/utils.js
@@ -615,12 +615,11 @@ export class Utils {
 
   __shuffle(num, array) {
     //https://stackoverflow.com/questions/18806210/generating-non-repeating-random-numbers-in-js/18806417
-    var i = array.length,
-      j = 0,
+    var j,
       temp;
 
-    while (i--) {
-      j = Math.floor(Math.random() * (i + 1));
+    for (let i = 0; i < num; i++) {
+      j = Math.floor(Math.random() * (array.length - i)) + i;
 
       // swap randomly chosen element with current element
       temp = array[i];

--- a/danfojs/tests/core/utils.js
+++ b/danfojs/tests/core/utils.js
@@ -217,4 +217,20 @@ describe("Utils Functions", function () {
     });
   });
 
+  describe("__shuffle", function() {
+    it("returns array with correct shape", function() {
+      let data = [ 1, 2, 3, 4, 5 ];
+      assert.deepEqual(utils.__shuffle(3, data).length, 3);
+    });
+
+    it("returns original values when num equals total length", function() {
+      let data = [ 1, 2, 3, 4, 5 ];
+      assert.deepEqual(utils.__shuffle(5, data).sort(), [ 1, 2, 3, 4, 5 ]);
+    });
+
+    it("returns empty array when num equals zero", function() {
+      let data = [ 1, 2, 3, 4, 5 ];
+      assert.deepEqual(utils.__shuffle(0, data), []);
+    });
+  });
 });


### PR DESCRIPTION
This is a small refactor of `__shuffle` to do only `num` instead of `array.length` total swaps, which could make a difference if `num` is small in relation to `array.length`.