### PR TITLE
fix: merge operation when values contain underscores

### DIFF
--- a/danfojs-browser/src/core/merge.js
+++ b/danfojs-browser/src/core/merge.js
@@ -75,19 +75,17 @@ export class Merge {
          keys combination.
          */
     for (let i = 0; i < left_values.length; i++) {
-
       let left_value = left_values[i];
-      let right_value = right_values[i];
-
-      let right_key_comb = "";
-      let left_key_comb = "";
+      let left_key_comb_values = [];
 
       //get the value in the column index
       for (let j = 0; j < this.left_col_index.length; j++) {
         let index = this.left_col_index[j];
 
-        left_key_comb += `_${left_value[index]}`;
+        left_key_comb_values.push(left_value[index]);
       }
+      //combine into single hashable string
+      let left_key_comb = left_key_comb_values.join('_');
 
       let self = this; // assign the this scope to self
       //filter out the value that are not the column key
@@ -99,30 +97,38 @@ export class Merge {
       //before storing the key combination and the value
       //associated with it
       if (utils.__key_in_object(this.left_key_dict, left_key_comb)) {
-        this.left_key_dict[left_key_comb].push(left_value_filter);
+        this.left_key_dict[left_key_comb].filters.push(left_value_filter);
       } else {
-        this.left_key_dict[left_key_comb] = [ left_value_filter ];
+        this.left_key_dict[left_key_comb] = {
+          filters: [left_value_filter],
+          comb_values: left_key_comb_values
+        };
       }
 
     }
     for (let i = 0; i < right_values.length; i++) {
       let right_value = right_values[i];
-      let right_key_comb = "";
+      let right_key_comb_values = [];
 
       for (let j = 0; j < this.right_col_index.length; j++) {
         let index = this.right_col_index[j];
 
-        right_key_comb += `_${right_value[index]}`;
+        right_key_comb_values.push(right_value[index]);
       }
+      let right_key_comb = right_key_comb_values.join('_');
+
       let self = this;
       let right_value_filter = right_value.filter(function (val, index) {
         return !self.right_col_index.includes(index);
       });
 
       if (utils.__key_in_object(this.right_key_dict, right_key_comb)) {
-        this.right_key_dict[right_key_comb].push(right_value_filter);
+        this.right_key_dict[right_key_comb].filters.push(right_value_filter);
       } else {
-        this.right_key_dict[right_key_comb] = [ right_value_filter ];
+        this.right_key_dict[right_key_comb] = {
+          filters: [right_value_filter],
+          comb_values: right_key_comb_values
+        };
       }
     }
 
@@ -242,7 +248,8 @@ export class Merge {
       });
 
       if (utils.__key_in_object(this.left_key_dict, key)) {
-        let left_row = this.left_key_dict[key];
+        let left_row = this.left_key_dict[key].filters;
+        let key_array = this.left_key_dict[key].comb_values;
 
 
         for (let left_i = 0; left_i < left_row.length; left_i++) {
@@ -251,7 +258,7 @@ export class Merge {
 
           if (utils.__key_in_object(this.right_key_dict, key)) {
 
-            let right_row = this.right_key_dict[key];
+            let right_row = this.right_key_dict[key].filters;
 
             for (let r_i = 0; r_i < right_row.length; r_i++) {
 
@@ -280,7 +287,8 @@ export class Merge {
         }
       } else {
 
-        let right_row = this.right_key_dict[key];
+        let right_row = this.right_key_dict[key].filters;
+        let key_array = this.right_key_dict[key].comb_values;
 
         for (let i = 0; i < right_row.length; i++) {
 

--- a/danfojs-node/dist/core/merge.js
+++ b/danfojs-node/dist/core/merge.js
@@ -69,45 +69,51 @@ class Merge {
 
     for (let i = 0; i < left_values.length; i++) {
       let left_value = left_values[i];
-      let right_value = right_values[i];
-      let right_key_comb = "";
-      let left_key_comb = "";
+      let left_key_comb_values = [];
 
       for (let j = 0; j < this.left_col_index.length; j++) {
         let index = this.left_col_index[j];
-        left_key_comb += `_${left_value[index]}`;
+        left_key_comb_values.push(left_value[index]);
       }
 
+      let left_key_comb = left_key_comb_values.join('_');
       let self = this;
       let left_value_filter = left_value.filter(function (val, index) {
         return !self.left_col_index.includes(index);
       });
 
       if (utils.__key_in_object(this.left_key_dict, left_key_comb)) {
-        this.left_key_dict[left_key_comb].push(left_value_filter);
+        this.left_key_dict[left_key_comb].filters.push(left_value_filter);
       } else {
-        this.left_key_dict[left_key_comb] = [left_value_filter];
+        this.left_key_dict[left_key_comb] = {
+          filters: [left_value_filter],
+          comb_values: left_key_comb_values
+        };
       }
     }
 
     for (let i = 0; i < right_values.length; i++) {
       let right_value = right_values[i];
-      let right_key_comb = "";
+      let right_key_comb_values = [];
 
       for (let j = 0; j < this.right_col_index.length; j++) {
         let index = this.right_col_index[j];
-        right_key_comb += `_${right_value[index]}`;
+        right_key_comb_values.push(right_value[index]);
       }
 
+      let right_key_comb = right_key_comb_values.join('_');
       let self = this;
       let right_value_filter = right_value.filter(function (val, index) {
         return !self.right_col_index.includes(index);
       });
 
       if (utils.__key_in_object(this.right_key_dict, right_key_comb)) {
-        this.right_key_dict[right_key_comb].push(right_value_filter);
+        this.right_key_dict[right_key_comb].filters.push(right_value_filter);
       } else {
-        this.right_key_dict[right_key_comb] = [right_value_filter];
+        this.right_key_dict[right_key_comb] = {
+          filters: [right_value_filter],
+          comb_values: right_key_comb_values
+        };
       }
     }
 
@@ -206,13 +212,14 @@ class Merge {
       });
 
       if (utils.__key_in_object(this.left_key_dict, key)) {
-        let left_row = this.left_key_dict[key];
+        let left_row = this.left_key_dict[key].filters;
+        let key_array = this.left_key_dict[key].comb_values;
 
         for (let left_i = 0; left_i < left_row.length; left_i++) {
           let left_row_row = left_row[left_i];
 
           if (utils.__key_in_object(this.right_key_dict, key)) {
-            let right_row = this.right_key_dict[key];
+            let right_row = this.right_key_dict[key].filters;
 
             for (let r_i = 0; r_i < right_row.length; r_i++) {
               let right_row_row = right_row[r_i];
@@ -235,7 +242,8 @@ class Merge {
           }
         }
       } else {
-        let right_row = this.right_key_dict[key];
+        let right_row = this.right_key_dict[key].filters;
+        let key_array = this.right_key_dict[key].comb_values;
 
         for (let i = 0; i < right_row.length; i++) {
           let right_row_row = right_row[i];

--- a/danfojs-node/src/core/merge.js
+++ b/danfojs-node/src/core/merge.js
@@ -75,19 +75,17 @@ export class Merge {
          keys combination.
          */
     for (let i = 0; i < left_values.length; i++) {
-
       let left_value = left_values[i];
-      let right_value = right_values[i];
-
-      let right_key_comb = "";
-      let left_key_comb = "";
+      let left_key_comb_values = [];
 
       //get the value in the column index
       for (let j = 0; j < this.left_col_index.length; j++) {
         let index = this.left_col_index[j];
 
-        left_key_comb += `_${left_value[index]}`;
+        left_key_comb_values.push(left_value[index]);
       }
+      //combine into single hashable string
+      let left_key_comb = left_key_comb_values.join('_');
 
       let self = this; // assign the this scope to self
       //filter out the value that are not the column key
@@ -99,30 +97,38 @@ export class Merge {
       //before storing the key combination and the value
       //associated with it
       if (utils.__key_in_object(this.left_key_dict, left_key_comb)) {
-        this.left_key_dict[left_key_comb].push(left_value_filter);
+        this.left_key_dict[left_key_comb].filters.push(left_value_filter);
       } else {
-        this.left_key_dict[left_key_comb] = [ left_value_filter ];
+        this.left_key_dict[left_key_comb] = {
+          filters: [left_value_filter],
+          comb_values: left_key_comb_values
+        };
       }
 
     }
     for (let i = 0; i < right_values.length; i++) {
       let right_value = right_values[i];
-      let right_key_comb = "";
+      let right_key_comb_values = [];
 
       for (let j = 0; j < this.right_col_index.length; j++) {
         let index = this.right_col_index[j];
 
-        right_key_comb += `_${right_value[index]}`;
+        right_key_comb_values.push(right_value[index]);
       }
+      let right_key_comb = right_key_comb_values.join('_');
+
       let self = this;
       let right_value_filter = right_value.filter(function (val, index) {
         return !self.right_col_index.includes(index);
       });
 
       if (utils.__key_in_object(this.right_key_dict, right_key_comb)) {
-        this.right_key_dict[right_key_comb].push(right_value_filter);
+        this.right_key_dict[right_key_comb].filters.push(right_value_filter);
       } else {
-        this.right_key_dict[right_key_comb] = [ right_value_filter ];
+        this.right_key_dict[right_key_comb] = {
+          filters: [right_value_filter],
+          comb_values: right_key_comb_values
+        };
       }
     }
 
@@ -242,7 +248,8 @@ export class Merge {
       });
 
       if (utils.__key_in_object(this.left_key_dict, key)) {
-        let left_row = this.left_key_dict[key];
+        let left_row = this.left_key_dict[key].filters;
+        let key_array = this.left_key_dict[key].comb_values;
 
 
         for (let left_i = 0; left_i < left_row.length; left_i++) {
@@ -251,7 +258,7 @@ export class Merge {
 
           if (utils.__key_in_object(this.right_key_dict, key)) {
 
-            let right_row = this.right_key_dict[key];
+            let right_row = this.right_key_dict[key].filters;
 
             for (let r_i = 0; r_i < right_row.length; r_i++) {
 
@@ -280,7 +287,8 @@ export class Merge {
         }
       } else {
 
-        let right_row = this.right_key_dict[key];
+        let right_row = this.right_key_dict[key].filters;
+        let key_array = this.right_key_dict[key].comb_values;
 
         for (let i = 0; i < right_row.length; i++) {
 


### PR DESCRIPTION
`danfojs-browser/src/core/merge.js` stores sets of values by joining them with an underscore, and later splitting on underscore. however, when the values themselves contain underscores, this becomes problematic, as this split causes nonsensical columns to be defined when indexing the data. 

this PR solves that issue by passing an array of values alongside the comb. specifically, the `left/right_key_dict` objects are changed from `comb: [filters]` to the following:
```js
comb: {
  filters: [filters],
  comb_values: [values]
}
```

when the comb values need to be accessed, the comb is not split on `_` anymore, but the comb_values are simply accessed.