### PR TITLE
[enhancement] Support freq offset above 10 and above for date_range()

### DIFF
--- a/danfojs-browser/src/core/date_range.js
+++ b/danfojs-browser/src/core/date_range.js
@@ -46,9 +46,11 @@ export class date_range {
         throw new Error(`invalid freq ${this.freq}`);
       }
     } else {
-      let freq_split = this.freq.split("");
-      this.offset = parseInt(freq_split[0]);
-      this.freq = freq_split[1];
+      this.offset = parseInt(this.freq.slice(0, -1));
+      if (!Number.isFinite(this.offset)){
+        throw new Error(`invalid freq offset ${this.freq.slice(0, -1)}`);
+      }
+      this.freq = this.freq.slice(-1);
       if (!this.freq_list.includes(this.freq)){
         throw new Error(`invalid freq ${this.freq}`);
       }

--- a/danfojs-browser/tests/core/date_range.js
+++ b/danfojs-browser/tests/core/date_range.js
@@ -47,6 +47,21 @@ describe("date_range", function(){
 
 
   });
+  it("Obtain date between start with end not specified, but period and freq specified, plus offset, longer freq", function(){
+
+    let d = new dfd.date_range({ start:'1/1/2018', period:5, freq:'35m' });
+    let rslt = [
+      "1/1/2018, 12:00:00 AM",
+      "1/1/2018, 12:35:00 AM",
+      "1/1/2018, 1:10:00 AM",
+      "1/1/2018, 1:45:00 AM",
+      "1/1/2018, 2:20:00 AM"
+    ];
+
+    assert.deepEqual(d, rslt);
+
+
+  });
   it("Obtain date range with start not specified but end and period is given", function(){
 
     let d = new dfd.date_range({ end:'1/1/2018', period:8 });
@@ -70,5 +85,8 @@ describe("date_range", function(){
   });
   it("inputing wrong freq with offset", function(){
     assert.throws(function () { new dfd.date_range({ end:'1/1/2018', period:8, freq:"4d" }); }, Error, 'invalid freq d');
+  });
+  it("inputing wrong freq offset", function(){
+    assert.throws(function () { new dfd.date_range({ end:'1/1/2018', period:8, freq:"abcm" }); }, Error, 'invalid freq offset abc');
   });
 });

--- a/danfojs-node/src/core/date_range.js
+++ b/danfojs-node/src/core/date_range.js
@@ -46,9 +46,11 @@ export class date_range {
         throw new Error(`invalid freq ${this.freq}`);
       }
     } else {
-      let freq_split = this.freq.split("");
-      this.offset = parseInt(freq_split[0]);
-      this.freq = freq_split[1];
+      this.offset = parseInt(this.freq.slice(0, -1));
+      if (!Number.isFinite(this.offset)){
+        throw new Error(`invalid freq offset ${this.freq.slice(0, -1)}`);
+      }
+      this.freq = this.freq.slice(-1);
       if (!this.freq_list.includes(this.freq)){
         throw new Error(`invalid freq ${this.freq}`);
       }

--- a/danfojs-node/tests/core/date_range.js
+++ b/danfojs-node/tests/core/date_range.js
@@ -48,6 +48,21 @@ describe("date_range", function(){
 
 
   });
+  it("Obtain date between start with end not specified, but period and freq specified, plus offset, longer freq", function(){
+
+    let d = new date_range({ start:'1/1/2018', period:5, freq:'35m' });
+    let rslt = [
+      "1/1/2018, 12:00:00 AM",
+      "1/1/2018, 12:35:00 AM",
+      "1/1/2018, 1:10:00 AM",
+      "1/1/2018, 1:45:00 AM",
+      "1/1/2018, 2:20:00 AM"
+    ];
+
+    assert.deepEqual(d, rslt);
+
+
+  });
   it("Obtain date range with start not specified but end and period is given", function(){
 
     let d = new date_range({ end:'1/1/2018', period:8 });
@@ -71,5 +86,8 @@ describe("date_range", function(){
   });
   it("inputing wrong freq with offset", function(){
     assert.throws(function () { new date_range({ end:'1/1/2018', period:8, freq:"4d" }); }, Error, 'invalid freq d');
+  });
+  it("inputing wrong freq offset", function(){
+    assert.throws(function () { new date_range({ end:'1/1/2018', period:8, freq:"abcm" }); }, Error, 'invalid freq offset abc');
   });
 });


### PR DESCRIPTION
This patch allows using a freq offset with more than one digit like `99D` or `123s` for the `date_range()` function.
Usage example: `date_range({ start:'1/1/2018', period:5, freq:'35m' })`