### PR TITLE
fix(dataframe): ensure consistent column order during creation from objects

### DIFF
--- a/src/danfojs-base/core/generic.ts
+++ b/src/danfojs-base/core/generic.ts
@@ -133,16 +133,16 @@ export default class NDframe implements NDframeInterface {
     */
     private loadObjectIntoNdframe({ data, type, index, columns, dtypes }: LoadObjectDataType): void {
         if (type === 1 && Array.isArray(data)) {
-            const _data = (data).map((item) => {
-                return Object.values(item);
-            });
+            let _columnNames = Object.keys(data[0]);
 
-            let _columnNames;
+            const _data = data.map((item: Record<string, any>) => {
+                return _columnNames.map((col: string) => {
+                    return item[col];
+                })
+            });
 
             if (columns) {
                 _columnNames = columns
-            } else {
-                _columnNames = Object.keys((data)[0]);
             }
 
             this.loadArrayIntoNdframe({ data: _data, index, columns: _columnNames, dtypes });

--- a/src/danfojs-node/test/core/frame.test.ts
+++ b/src/danfojs-node/test/core/frame.test.ts
@@ -83,6 +83,20 @@ describe("DataFrame", function () {
                 assert.deepEqual(df.values[3], [1, 4, 90.1]);
                 assert.deepEqual(df.dtypes, ["float32", "int32", "float32",]);
             });
+
+            it("correctly converts to column-oriented JSON", function () {
+                const jsonData = [
+                    { campaignId: "toyota", agentId: "bob", metricValue: 1, metricId: "callCount" },
+                    { campaignId: "toyota", agentId: "jim", metricValue: 2, metricId: "callCount" },
+                    { campaignId: "sony", agentId: "ben", metricValue: 3, metricId: "callCount" },
+                    { campaignId: "sony", agentId: "karl", metricId: "callCount", metricValue: 4 },
+                ];
+
+                const df = new DataFrame(jsonData);
+                const columnJSON = df.toJSON({ format: "column" });
+
+                assert.deepEqual(columnJSON, jsonData);
+            });
         })
 
         describe("addColumn", function () {


### PR DESCRIPTION
Fix: Consistent column order for DataFrame from objects (#556, #641)

Addresses issue #556, #641. DataFrame creation from objects now preserves consistent column order.

**Changes:**

Modified `loadObjectIntoNdframe` in `src/danfojs-base/core/generic.ts`. Reads column names from the first object's keys. Extracts values based on this order.

**Considerations:**

Column order follows the first object's keys.

**Testing:**

Added a unit test in `src/danfojs-node/test/core/frame.test.ts` to verify consistent column order.
