### PR TITLE
Fixed Replacing a value with 0 with dataframe.replace throws an error

### DIFF
--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -2759,16 +2759,24 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
     ): DataFrame | void {
         const { columns, inplace } = { inplace: false, ...options }
 
-        if (typeof oldValue === 'number' && isNaN(oldValue)) {
-            throw Error(`Params Error: Param 'oldValue' does not support NaN. Use DataFrame.fillNa() instead.`);
-        }
-
-        if (!oldValue && typeof oldValue !== 'boolean' && typeof oldValue !== 'number' && typeof oldValue !== 'string') {
+        if (oldValue === undefined) {
             throw Error(`Params Error: Must specify param 'oldValue' to replace`);
         }
 
-        if (!newValue && typeof newValue !== 'boolean' && typeof newValue !== 'number' && typeof newValue !== 'string') {
+        if (newValue === undefined) {
             throw Error(`Params Error: Must specify param 'newValue' to replace with`);
+        }
+
+        if (typeof oldValue === 'number' && isNaN(oldValue)) {
+            throw Error(`Params Error: Param 'oldValue' does not support NaN. Use Series.fillNa() instead.`);
+        }
+
+        if (typeof oldValue !== 'boolean' && typeof oldValue !== 'number' && typeof oldValue !== 'string') {
+            throw Error(`Params Error: Param 'oldValue' must be of type string or number or boolean.`);
+        }
+
+        if (typeof newValue !== 'boolean' && typeof newValue !== 'number' && typeof newValue !== 'string') {
+            throw Error(`Params Error: Param 'newValue' must be of type string or number or boolean.`);
         }
 
         let newData: ArrayType2D = []

--- a/src/danfojs-base/core/series.ts
+++ b/src/danfojs-base/core/series.ts
@@ -1536,16 +1536,24 @@ export default class Series extends NDframe implements SeriesInterface {
     ): Series | void {
         const { inplace } = { inplace: false, ...options }
 
+        if (oldValue === undefined) {
+            throw Error(`Params Error: Must specify param 'oldValue' to replace`);
+        }
+
+        if (newValue === undefined) {
+            throw Error(`Params Error: Must specify param 'newValue' to replace with`);
+        }
+
         if (typeof oldValue === 'number' && isNaN(oldValue)) {
             throw Error(`Params Error: Param 'oldValue' does not support NaN. Use Series.fillNa() instead.`);
         }
 
-        if (!oldValue && typeof oldValue !== 'boolean' && typeof oldValue !== 'number' && typeof oldValue !== 'string') {
-            throw Error(`Params Error: Must specify param 'oldValue' to replace`);
+        if (typeof oldValue !== 'boolean' && typeof oldValue !== 'number' && typeof oldValue !== 'string') {
+            throw Error(`Params Error: Param 'oldValue' must be of type string or number or boolean.`);
         }
 
-        if (!newValue && typeof newValue !== 'boolean' && typeof newValue !== 'number' && typeof newValue !== 'string') {
-            throw Error(`Params Error: Must specify param 'newValue' to replace with`);
+        if (typeof newValue !== 'boolean' && typeof newValue !== 'number' && typeof newValue !== 'string') {
+            throw Error(`Params Error: Param 'newValue' must be of type string or number or boolean.`);
         }
 
         const newArr = [...this.values].map((val) => {


### PR DESCRIPTION
Fixes #621

The original implementation wrongly tests falsy on oldValue and newValue, which results in throwing when replacing with falsy values like 0 or empty string.

This fix test for undefined instead, then validates oldValue/newValue types.

This fix is trivial so no test coverage.

* Previous PR was closed due to editor removal of whitespace that spamming diff log