### PR TITLE
Fixed error: File format not supported! while trying to reassign a column.

### DIFF
--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -177,7 +177,7 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
                 (this.$data as any)[i][columnIndex] = colunmValuesToAdd[i]
             }
             //Update column ($dataIncolumnFormat) array since it's available in object
-            (this.$dataIncolumnFormat as any)[columnIndex] = arr
+            (this.$dataIncolumnFormat as any)[columnIndex] = colunmValuesToAdd
 
             //Update the dtypes
             this.$dtypes[columnIndex] = utils.inferDtype(colunmValuesToAdd)[0]


### PR DESCRIPTION
Fixes #616

In the original implementation, setter function $setColumnData wrongly assigns selected column to arr directly. If arr is a Series, this results in failure of type check which lead to the confusing "File format not supported" exception. 

This fix assigns correct extracted values colunmValuesToAdd to selected columns.

Unit test addColumn pass, no new tests needed for coverage.