### PR TITLE
Fixed loc with one row cause error

### DIFF
--- a/src/danfojs-base/core/indexing.ts
+++ b/src/danfojs-base/core/indexing.ts
@@ -243,7 +243,10 @@ export function _loc({ ndFrame, rows, columns }: {
             if (rows[0].startsWith(`"`) || rows[0].startsWith(`'`) || rows[0].startsWith("`")) {
                 temp = _index.indexOf(rows[0].replace(/['"`]/g, ''))
             } else {
-                temp = _index.indexOf(Number(rows[0]))
+                temp = _index.indexOf(rows[0]);
+                if (temp === -1 && !isNaN(Number(rows[0]))) {
+                    temp = _index.indexOf(Number(rows[0]));
+                }
             }
 
             if (temp === -1) {


### PR DESCRIPTION
Fixes #597

The original implementation directly cast single rows of string to Number, which can result in NaN if rows is literal index.

This fix finds indexOf the row without casting, and if index not found, then tries to cast to Number. This covers both literal index and row number.

No regression reported by test.