### PR TITLE
Fixed `sf.apply` not working with dates

### DIFF
--- a/src/danfojs-base/shared/utils.ts
+++ b/src/danfojs-base/shared/utils.ts
@@ -371,6 +371,7 @@ export default class Utils {
             typeof arr[0] == "number" ||
             typeof arr[0] == "string" ||
             typeof arr[0] == "boolean" ||
+            arr[0] instanceof Date ||
             arr[0] === null
         ) {
             return true;


### PR DESCRIPTION
Fixes #574

This PR added missing check instanceof Date in is1DArray. Now the method won't treat array of Date as 2D array anymore.

No regression.